### PR TITLE
Update to latest libraries

### DIFF
--- a/Kinetic2MQTT.ino
+++ b/Kinetic2MQTT.ino
@@ -77,10 +77,20 @@ void setup() {
   radio.setCrcFiltering(false);
   radio.fixedPacketLengthMode(PACKET_LENGTH);
 
+  //
+  // Because the sync word we're using is just before
+  // the payload and does not immediately follow the
+  // preamble as normal, we need to disable the preamble
+  // quality threshold (PQT) which would otherwise
+  // prevent the sync word from being recognised
+  // in RadioLib >= 6.0.0.
+  //
+  radio.setPreambleLength(PREAMBLE_LENGTH, 0);
+
   uint8_t syncWord[] = {0xA4, 0x23};
   radio.setSyncWord(syncWord, 2);
 
-  radio.setGdo0Action(setFlag);
+  radio.setGdo0Action(setFlag, RISING);
 
   state = radio.startReceive();
   if (state == RADIOLIB_ERR_NONE) {

--- a/README.md
+++ b/README.md
@@ -26,6 +26,6 @@ Also bear in mind the following:
 
 The following libraries are used by Kinetic2MQTT.  They should be installed in your Arduino development environment prior to building:
 * IotWebConf version 3.2.1: https://github.com/prampec/IotWebConf
-* PubSubClient version 2.8.0: https://github.com/knolleary/pubsubclient/
-* RadioLib version 5.3.0: https://github.com/jgromes/RadioLib
-* AceCRC version 1.0.1: https://github.com/bxparks/AceCRC
+* PubSubClient version 2.8: https://github.com/knolleary/pubsubclient/
+* RadioLib version 7.4.0: https://github.com/jgromes/RadioLib
+* AceCRC version 1.1.1: https://github.com/bxparks/AceCRC


### PR DESCRIPTION
The update to RadioLib 6.0.0 introduced two important changes:

* Requirement to explicitly indicate signal change direction in setGdo0Action
* Need to suppress preamble quality threshold because of position of sync word

Ideally, the latter would be solved by using a sync word which immediately follows the preamble, but the option used here keeps the previous behaviour with minimal changes.

I raised a (now closed) issue on RadioLib when I was trying to figure out why updating it to 6.0.0 didn't work:

<https://github.com/jgromes/RadioLib/issues/1634>

I might look into picking a new sync word later, as my plan is to use this code as a basis for something a bit more complicated: I have a receiver which appears to respond to switch pushes and I'd like to monitor that, so having the full packet available is probably a good idea. That's going to require digging the SDR out of the drawer and reproducing your setup from the video, so this seemed like a good first step.